### PR TITLE
case sensitive grades

### DIFF
--- a/packages/t2l-backend/src/apiHandlers/canvasGrades.ts
+++ b/packages/t2l-backend/src/apiHandlers/canvasGrades.ts
@@ -23,7 +23,7 @@ export async function assignmentGradesHandler(
         id: s.user.integration_id,
         sortableName: s.user.sortable_name,
       },
-      grade: s.grade,
+      grade: s.grade?.toUpperCase() ?? null,
       gradedAt: s.graded_at,
       submittedAt: s.submitted_at,
     }))
@@ -50,7 +50,7 @@ export async function courseGradesHandler(
         id: e.user.integration_id,
         sortableName: e.user.sortable_name,
       },
-      grade: e.grades?.unposted_current_grade,
+      grade: e.grades?.unposted_current_grade.toUpperCase() ?? null,
       gradedAt: null,
       submittedAt: null,
     }))

--- a/packages/t2l-backend/src/apiHandlers/utils/postOneResult.ts
+++ b/packages/t2l-backend/src/apiHandlers/utils/postOneResult.ts
@@ -31,7 +31,9 @@ function formatInputForLadok(
 ): Resultat {
   const letterGrade = input.draft.grade;
   const scaleId = gradingInformation._obj.Rapporteringskontext.BetygsskalaID;
-  const gradeId = getBetyg(scaleId).find((b) => b.Kod === letterGrade)?.ID;
+  const gradeId = getBetyg(scaleId).find(
+    (b) => b.Kod.toUpperCase() === letterGrade.toUpperCase()
+  )?.ID;
 
   if (!gradeId) {
     throw new PostResultError(


### PR DESCRIPTION
- Find Ladok grade ID case-sensitive
- T2L backend respond always with upper-case grades
