### PR TITLE
Fix Ladok URL for production

### DIFF
--- a/packages/t2l-backend/src/apiHandlers/sections.ts
+++ b/packages/t2l-backend/src/apiHandlers/sections.ts
@@ -13,6 +13,21 @@ import {
   Kurstillfalle,
 } from "../externalApis/ladokApi";
 
+// Maps between possible "LADOK_API_BASE_URL" and Ladok root URL (frontend).
+const ALL_LADOK_ROOTS: Record<string, string> = {
+  "https://api.integrationstest.ladok.se":
+    "https://www.integrationstest.ladok.se",
+  "https://api.ladok.se": "https://www.start.ladok.se",
+};
+
+const LADOK_ROOT = ALL_LADOK_ROOTS[process.env.LADOK_BASE_URL || ""];
+
+if (!LADOK_ROOT) {
+  throw new Error(
+    `Incorrect LADOK_BASE_URL [${process.env.LADOK_BASE_URL}]. There is no Frontend URL associated with it`
+  );
+}
+
 export function formatAktivitetstillfalle(
   uid: string,
   ladokAkt: Aktivitetstillfalle
@@ -23,11 +38,13 @@ export function formatAktivitetstillfalle(
   );
   const date = ladokAkt.Datumperiod.Startdatum;
   const name = codes.join(" & ") + " - " + date;
+  const url = `${LADOK_ROOT}/gui/app/gui/#/studiedokumentation/aktivitetstillfalleshantering/${uid}/rapportering`;
 
   return {
     id: uid,
     name,
     date,
+    url,
   };
 }
 
@@ -43,10 +60,12 @@ export function formatKurstillfalle(
     utbildningsinstans: ladokKur.UtbildningsinstansUID,
     courseCode: ladokKur.Utbildningskod,
     roundCode: ladokKur.Kurstillfalleskod,
+    url: `${LADOK_ROOT}/gui/app/gui/#/studiedokumentation/resultathantering/${ladokKur.UtbildningsinstansUID}/rapportering/rapportera/${ladokKur.UtbildningsinstansUID}?valtKurstillfalle=${uid}`,
     modules: ladokKur.IngaendeMoment.map((m) => ({
       utbildningsinstans: m.UtbildningsinstansUID,
       code: m.Utbildningskod,
       name: m.Benamning.sv,
+      url: `${LADOK_ROOT}/gui/app/gui/#/studiedokumentation/resultathantering/${ladokKur.UtbildningsinstansUID}/rapportering/rapportera/${m.UtbildningsinstansUID}?valtKurstillfalle=${uid}`,
     })),
   };
 }

--- a/packages/t2l-backend/src/apiHandlers/sections.ts
+++ b/packages/t2l-backend/src/apiHandlers/sections.ts
@@ -20,11 +20,11 @@ const ALL_LADOK_ROOTS: Record<string, string> = {
   "https://api.ladok.se": "https://www.start.ladok.se",
 };
 
-const LADOK_ROOT = ALL_LADOK_ROOTS[process.env.LADOK_BASE_URL || ""];
+const LADOK_ROOT = ALL_LADOK_ROOTS[process.env.LADOK_API_BASEURL || ""];
 
 if (!LADOK_ROOT) {
   throw new Error(
-    `Incorrect LADOK_BASE_URL [${process.env.LADOK_BASE_URL}]. There is no Frontend URL associated with it`
+    `Incorrect environmental variable LADOK_API_BASEURL [${process.env.LADOK_BASE_URL}]. There is no Frontend URL associated with it`
   );
 }
 

--- a/packages/t2l-backend/src/apiHandlers/utils/types.ts
+++ b/packages/t2l-backend/src/apiHandlers/utils/types.ts
@@ -24,6 +24,9 @@ export interface AktivitetstillfalleSection {
 
   /** Date when the aktivitetstillfälle is held. Example: 2022-01-01 */
   date: string;
+
+  /** Go to this URL to report grades in this Aktivitetstillfälle  */
+  url: string;
 }
 
 /** A Canvas Section linked with a Ladok kurstillfalle  */
@@ -40,6 +43,9 @@ export type KurstillfalleSection = {
   /** Code for kurstillfälle: "50071" */
   roundCode: string;
 
+  /** Go to this URL to report final grades of this kurstillfälle */
+  url: string;
+
   /** Modules in the kurstillfälle */
   modules: {
     /** Use this identifier to send grades to this specific module */
@@ -50,6 +56,9 @@ export type KurstillfalleSection = {
 
     /** Human readable name of the module. Example: "Examination" */
     name: string;
+
+    /** Go to this URL to report grades for this module */
+    url: string;
   }[];
 };
 

--- a/packages/t2l-frontend/src/screens/Authenticated.tsx
+++ b/packages/t2l-frontend/src/screens/Authenticated.tsx
@@ -7,7 +7,7 @@ import {
 import { SendGradesInput, useSendGrades } from "../hooks/useSendGrades";
 import Preview from "./Preview";
 import Done from "./Done";
-import ModuleSelector from "./ModuleSelector";
+import ModuleSelector, { type DestinationWithUrl } from "./ModuleSelector";
 import { ArrowLeft } from "../utils/icons";
 
 import "./Authenticated.scss";
@@ -60,13 +60,11 @@ function AppWithSelector({
   sections: Sections;
   onSubmit(results: SendGradesInput): void;
 }) {
-  const [destination, setDestination] = React.useState<GradesDestination>();
+  const [selection, setSelection] = React.useState<DestinationWithUrl>();
 
-  if (!destination) {
-    return <ModuleSelector sections={sections} onSelect={setDestination} />;
+  if (!selection) {
+    return <ModuleSelector sections={sections} onSelect={setSelection} />;
   }
-
-  const ladokUrl = getLadokUrl(sections, destination);
 
   return (
     <div className="Authenticated">
@@ -76,7 +74,7 @@ function AppWithSelector({
           className="with-icon"
           onClick={(e) => {
             e.preventDefault();
-            setDestination(undefined);
+            setSelection(undefined);
           }}
         >
           <ArrowLeft />
@@ -84,10 +82,10 @@ function AppWithSelector({
         </a>
       </header>
       <Preview
-        ladokUrl={ladokUrl}
-        destination={destination}
-        destinationName={getName(sections, destination) || ""}
-        fixedExaminationDate={getDate(sections, destination)}
+        ladokUrl={selection.url}
+        destination={selection.destination}
+        destinationName={getName(sections, selection.destination) || ""}
+        fixedExaminationDate={getDate(sections, selection.destination)}
         onSubmit={onSubmit}
       />
     </div>
@@ -96,18 +94,14 @@ function AppWithSelector({
 
 function AppWithoutSelector({
   akt,
-  sections,
   onSubmit,
 }: {
   akt: AktivitetstillfalleSection;
-  sections: Sections;
   onSubmit(results: SendGradesInput): void;
 }) {
-  const ladokUrl = getLadokUrl(sections, { aktivitetstillfalle: akt.id });
-
   return (
     <Preview
-      ladokUrl={ladokUrl}
+      ladokUrl={akt.url}
       destination={{ aktivitetstillfalle: akt.id }}
       destinationName={akt.name}
       fixedExaminationDate={akt.date}
@@ -154,11 +148,7 @@ export default function Authenticated({ sections }: { sections: Sections }) {
   // we don't show any selector
   if (aktivitetstillfalle.length === 1 && kurstillfalle.length === 0) {
     return (
-      <AppWithoutSelector
-        sections={sections}
-        akt={aktivitetstillfalle[0]}
-        onSubmit={koooor}
-      />
+      <AppWithoutSelector akt={aktivitetstillfalle[0]} onSubmit={koooor} />
     );
   }
 

--- a/packages/t2l-frontend/src/screens/ModuleSelector.tsx
+++ b/packages/t2l-frontend/src/screens/ModuleSelector.tsx
@@ -3,12 +3,17 @@ import { GradesDestination, Sections } from "t2l-backend/src/types";
 
 import "./ModuleSelector.scss";
 
+export interface DestinationWithUrl {
+  destination: GradesDestination;
+  url: string;
+}
+
 export default function ModuleSelector({
   sections,
   onSelect,
 }: {
   sections: Sections;
-  onSelect(destination: GradesDestination): void;
+  onSelect(destination: DestinationWithUrl): void;
 }) {
   return (
     <div className="ModuleSelector">
@@ -25,7 +30,10 @@ export default function ModuleSelector({
                 onClick={(e) => {
                   e.preventDefault();
                   onSelect({
-                    aktivitetstillfalle: a.id,
+                    url: a.url,
+                    destination: {
+                      aktivitetstillfalle: a.id,
+                    },
                   });
                 }}
               >
@@ -48,8 +56,11 @@ export default function ModuleSelector({
                   onClick={(e) => {
                     e.preventDefault();
                     onSelect({
-                      kurstillfalle: ktf.id,
-                      utbildningsinstans: m.utbildningsinstans,
+                      url: m.url,
+                      destination: {
+                        kurstillfalle: ktf.id,
+                        utbildningsinstans: m.utbildningsinstans,
+                      },
                     });
                   }}
                 >
@@ -64,8 +75,11 @@ export default function ModuleSelector({
                 onClick={(e) => {
                   e.preventDefault();
                   onSelect({
-                    kurstillfalle: ktf.id,
-                    utbildningsinstans: ktf.utbildningsinstans,
+                    url: ktf.url,
+                    destination: {
+                      kurstillfalle: ktf.id,
+                      utbildningsinstans: ktf.utbildningsinstans,
+                    },
                   });
                 }}
               >


### PR DESCRIPTION
This PR fixes the previously hard-coded Ladok URL to something that depends on the environment:

1. Ladok URL is returned by the API
2. Frontend reads the returned value from backend