### PR TITLE
Filter-out irrelevant drafts

### DIFF
--- a/packages/t2l-backend/src/apiHandlers/utils/GradingInformation.ts
+++ b/packages/t2l-backend/src/apiHandlers/utils/GradingInformation.ts
@@ -132,6 +132,15 @@ export default class GradingInformation {
       return;
     }
 
+    // Ladok returns all utkast for a student in a course, even outside of
+    // the current module. We need to filter-out it
+    if (
+      utkast?.UtbildningsinstansUID !==
+      this._obj.Rapporteringskontext.UtbildningsinstansUID
+    ) {
+      return;
+    }
+
     return {
       id: utkast.Uid,
       updatedAt: utkast.SenasteResultatandring,

--- a/packages/t2l-backend/src/externalApis/ladokApi/types.ts
+++ b/packages/t2l-backend/src/externalApis/ladokApi/types.ts
@@ -114,6 +114,9 @@ export interface Studieresultat {
        * update or delete a result
        */
       Uid: string;
+
+      /** Use this to filter-out "utkast" or "klarmarkerade" that are unrelated */
+      UtbildningsinstansUID: string;
     };
 
     /** Latest "atesterade" resultat if any */


### PR DESCRIPTION
This PR solves a bug that caused Transfer to Ladok to show results from unexpected "aktivitetstillfälle". For example: when requesting "MJ1112 TEN2", it returned drafts for "MJ1112 TEN1".

The root cause is that Ladok API returns such data, even when requesting explicitly for one aktivitetstillfälle meaning that we need to filter-out ourselves.