### PR TITLE
letter grade should not report a validation error

### DIFF
--- a/packages/t2l-frontend/src/screens/wizard/SelectionStep.tsx
+++ b/packages/t2l-frontend/src/screens/wizard/SelectionStep.tsx
@@ -40,8 +40,8 @@ function validateAssignment(
 
   if (assignmentId === "total") {
     return allColumns.finalGrades.hasLetterGrade
-      ? "The total column in this course does not have letter grades. Choose a different assignment or go to Canvas to configure letter grades for the course"
-      : undefined;
+      ? undefined
+      : "The total column in this course does not have letter grades. Choose a different assignment or go to Canvas to configure letter grades for the course";
   }
 
   const assignment = allColumns.assignments.find((a) => a.id === assignmentId);


### PR DESCRIPTION
This PR fixes an obvious bug: if the total column _has_ letter grade, the validation fails without this fix.