### PR TITLE
Cache "GradingInformation" object

### DIFF
--- a/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
+++ b/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
@@ -143,7 +143,8 @@ export async function postGradesHandler(
 
   const gradingInformation = await getGradingInformation(
     req.body.destination,
-    email
+    email,
+    { useCache: true }
   );
 
   const output: ResultOutput[] = [];

--- a/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
+++ b/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
@@ -31,17 +31,18 @@ async function getGradingInformation(
   destination: GradesDestination,
   teacherEmail: string,
   {
-    useCache,
+    readFromCache,
     session,
   }: {
-    useCache: boolean;
+    readFromCache: boolean;
     session: Partial<SessionData>;
   }
 ) {
   const key = JSON.stringify(destination);
   session.gradingInformation = session.gradingInformation || {};
 
-  if (!useCache || !session.gradingInformation[key]) {
+  // NOTE: the cache is updated regardless of the `readFromCache` flag
+  if (!readFromCache || !session.gradingInformation[key]) {
     const allStudieresultat = await getAllStudieresultat(destination);
     const allPermissions = await getAllPermissions(
       allStudieresultat,
@@ -134,7 +135,7 @@ export async function getGradesHandler(
   await checkPermissionProfile(email);
 
   const gradingInformation = await getGradingInformation(destination, email, {
-    useCache: false,
+    readFromCache: false,
     session: req.session,
   });
 
@@ -182,7 +183,7 @@ export async function postGradesHandler(
     req.body.destination,
     email,
     {
-      useCache: true,
+      readFromCache: true,
       session: req.session,
     }
   );

--- a/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
+++ b/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
@@ -18,11 +18,7 @@ import {
   assertPostLadokGradesInput,
 } from "./utils/asserts";
 import postOneResult from "./utils/postOneResult";
-import {
-  RapporteringsMojlighetOutput,
-  Studieresultat,
-  getKurstillfalleStructure,
-} from "../externalApis/ladokApi";
+import { getKurstillfalleStructure } from "../externalApis/ladokApi";
 import { insertTransference } from "../externalApis/mongo";
 import log from "skog";
 import GradingInformation, {
@@ -30,18 +26,6 @@ import GradingInformation, {
   getAllStudieresultat,
 } from "./utils/GradingInformation";
 import { SessionData } from "express-session";
-
-declare module "express-session" {
-  interface SessionData {
-    gradingInformation: Record<
-      string,
-      {
-        allStudieresultat: Studieresultat[];
-        allPermissions: RapporteringsMojlighetOutput;
-      }
-    >;
-  }
-}
 
 async function getGradingInformation(
   destination: GradesDestination,

--- a/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
+++ b/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
@@ -137,7 +137,6 @@ export async function getGradesHandler(
   res: Response<GradeableStudents>
 ) {
   const destination = req.query;
-  req.session.gradingInformation;
   assertGradesDestination(destination);
 
   const courseId = req.params.courseId;

--- a/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
+++ b/packages/t2l-backend/src/apiHandlers/ladokGrades.ts
@@ -143,8 +143,7 @@ export async function postGradesHandler(
 
   const gradingInformation = await getGradingInformation(
     req.body.destination,
-    email,
-    { useCache: true }
+    email
   );
 
   const output: ResultOutput[] = [];

--- a/packages/t2l-backend/src/apiHandlers/utils/GradingInformation.ts
+++ b/packages/t2l-backend/src/apiHandlers/utils/GradingInformation.ts
@@ -41,7 +41,7 @@ export async function _searchAllStudieresultat(
  * Given a list of {@link Studieresultat}, get a list of which ones the user
  * has permissions to send grades to.
  */
-export async function _getAllPermissions(
+export async function getAllPermissions(
   allStudieresultat: Studieresultat[],
   email: string
 ) {
@@ -59,7 +59,7 @@ export async function _getAllPermissions(
  * Given a destination ({@link GradesDestination}), get a list of all
  * {@link Studieresultat} in that destination
  */
-export async function _getAllStudieresultat(
+export async function getAllStudieresultat(
   destination: GradesDestination
 ): Promise<Studieresultat[]> {
   if ("aktivitetstillfalle" in destination) {
@@ -80,25 +80,6 @@ export async function _getAllStudieresultat(
       [destination.kurstillfalle]
     );
   }
-}
-
-/**
- * Given a destination ({@link GradesDestination}), get a list of all
- * {@link GradingInformation} in that destination
- */
-export async function getGradingInformation(
-  destination: GradesDestination,
-  teacherEmail: string
-) {
-  const allStudieresultat = await _getAllStudieresultat(destination);
-  const allPermissions = await _getAllPermissions(
-    allStudieresultat,
-    teacherEmail
-  );
-
-  return allStudieresultat.map(
-    (s) => new GradingInformation(s, allPermissions)
-  );
 }
 
 /**

--- a/packages/t2l-backend/src/apiHandlers/utils/GradingInformation.ts
+++ b/packages/t2l-backend/src/apiHandlers/utils/GradingInformation.ts
@@ -10,16 +10,6 @@ import {
   Studieresultat,
 } from "../../externalApis/ladokApi/types";
 
-// 30 minutes cache
-const CACHE_DURATION = 1000 * 60 * 30;
-const cachedGradingInformation = new Map<
-  string,
-  {
-    timestamp: number;
-    data: GradingInformation[];
-  }
->();
-
 /**
  * Calls {@link searchStudieresultat} and fetches all pages of results.
  */
@@ -96,7 +86,7 @@ export async function _getAllStudieresultat(
  * Given a destination ({@link GradesDestination}), get a list of all
  * {@link GradingInformation} in that destination
  */
-async function _getGradingInformation(
+export async function getGradingInformation(
   destination: GradesDestination,
   teacherEmail: string
 ) {
@@ -109,51 +99,6 @@ async function _getGradingInformation(
   return allStudieresultat.map(
     (s) => new GradingInformation(s, allPermissions)
   );
-}
-
-/**
- * Deletes all cached values that are older than CACHE_DURATION
- */
-function purgeCache() {
-  const now = Date.now();
-  for (const [key, value] of cachedGradingInformation) {
-    if (value.timestamp < now - CACHE_DURATION) {
-      cachedGradingInformation.delete(key);
-    }
-  }
-}
-
-/**
- * Get a list of all {@link GradingInformation} in a given destination.
- *
- * @param {boolean} options.useCache if true, the function returns an existing
- * cached value. Note: the function will always _save_ the retrieved value in
- * the cache regardless of this flag.
- */
-export async function getGradingInformation(
-  destination: GradesDestination,
-  teacherEmail: string,
-  options?: { useCache: boolean }
-) {
-  purgeCache();
-  const key = JSON.stringify({ destination, teacherEmail });
-
-  if (options?.useCache) {
-    const cached = cachedGradingInformation.get(key);
-
-    if (cached) {
-      return cached.data;
-    }
-  }
-
-  const result = await _getGradingInformation(destination, teacherEmail);
-
-  cachedGradingInformation.set(key, {
-    timestamp: Date.now(),
-    data: result,
-  });
-
-  return result;
 }
 
 /**

--- a/packages/t2l-backend/src/env.d.ts
+++ b/packages/t2l-backend/src/env.d.ts
@@ -1,0 +1,33 @@
+// Use "declaration merging" to add extra properties to diverse objects.
+// Read more: https://www.typescriptlang.org/docs/handbook/declaration-merging.html
+import type {
+  RapporteringsMojlighetOutput,
+  Studieresultat,
+} from "./externalApis/ladokApi/types";
+
+// Declare what is returned from Canvas oAuth
+declare module "openid-client" {
+  interface TokenSet {
+    user: {
+      id: number;
+    };
+  }
+}
+
+// Declare what is stored in the session
+declare module "express-session" {
+  interface SessionData {
+    tmpState: string;
+    tmpCourseId: string;
+    accessToken: string;
+    refreshToken: string;
+    userId: number;
+    gradingInformation: Record<
+      string,
+      {
+        allStudieresultat: Studieresultat[];
+        allPermissions: RapporteringsMojlighetOutput;
+      }
+    >;
+  }
+}

--- a/packages/t2l-backend/src/externalApis/canvasApi.ts
+++ b/packages/t2l-backend/src/externalApis/canvasApi.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../env.d.ts" />
 /**
  * This module contains functions to call Canvas API.
  * Functions do not contain any logic

--- a/packages/t2l-backend/src/otherHandlers/auth.ts
+++ b/packages/t2l-backend/src/otherHandlers/auth.ts
@@ -3,24 +3,6 @@ import { Router } from "express";
 import { Issuer, generators, errors } from "openid-client";
 import log from "skog";
 
-declare module "openid-client" {
-  interface TokenSet {
-    user: {
-      id: number;
-    };
-  }
-}
-
-declare module "express-session" {
-  interface SessionData {
-    tmpState: string;
-    tmpCourseId: string;
-    accessToken: string;
-    refreshToken: string;
-    userId: number;
-  }
-}
-
 // Assuming that this router is going to be in
 // https://localdev.kth.se:4443/transfer-to-ladok/auth
 const oauthRedirectUrl = new URL(

--- a/packages/t2l-backend/tsconfig.json
+++ b/packages/t2l-backend/tsconfig.json
@@ -24,5 +24,6 @@
 
     /* Completeness */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR caches `GradingInformation` object retrieved from Ladok.

Why to cache?

- Fetching `GradingInformation` from Ladok implies one request to Ladok for every 100 registered students. All the request can take aprox. 50 seconds for a course with 1000 students.
- The app fetches Ladok when showing the table of grades that will be sent.

  The loading time for the table is 50 seconds

- The app fetches the same information in every request to `POST /ladok-grades`, i.e. when the app sends results to Ladok.

  Sending 1000 results to Ladok takes 50 x 10 = 500 seconds.

- The relevant response from Ladok is identical in all requests.

This PR proposes to save the result of the first time the app performs the request and use the result for further requests.

- Showing the table still takes 50 seconds
- Sending 1000 results takes 40 seconds instead of 500