### PR TITLE
Show only students and show then once

### DIFF
--- a/packages/t2l-backend/src/apiHandlers/utils/commons.test.ts
+++ b/packages/t2l-backend/src/apiHandlers/utils/commons.test.ts
@@ -1,4 +1,4 @@
-import { splitSections } from "./commons";
+import { splitSections, unique } from "./commons";
 
 describe("splitSections", () => {
   it("should ignore non-Ladok sections", () => {
@@ -115,5 +115,33 @@ describe("splitSections", () => {
     };
     const actual = splitSections(input);
     expect(actual).toEqual(expected);
+  });
+});
+
+describe("unique", () => {
+  it("should work with primitives", () => {
+    const input = [1, 2, 3, 4, 1, 1, 4, 5];
+    const output = input.filter(unique());
+    const expected = [1, 2, 3, 4, 5];
+
+    expect(output).toEqual(expected);
+  });
+
+  it("should work with objects", () => {
+    const input = [
+      { id: 1, name: "X" },
+      { id: 2, name: "Y" },
+      { id: 1, name: "Z" },
+    ];
+    const output = input.filter(
+      // The `equalFn` passed considers two objects as equal when their `id` are the same
+      unique((a, b) => a.id === b.id)
+    );
+
+    const expected = [
+      { id: 1, name: "X" },
+      { id: 2, name: "Y" },
+    ];
+    expect(output).toEqual(expected);
   });
 });

--- a/packages/t2l-backend/src/apiHandlers/utils/commons.ts
+++ b/packages/t2l-backend/src/apiHandlers/utils/commons.ts
@@ -50,3 +50,18 @@ export async function checkPermissionProfile(email: string) {
     )
   );
 }
+
+/**
+ * Returns a predicate for {@link Array.filter}.
+ *
+ * The predicate returns true only if the element is the first appearance in
+ * the array.
+ *
+ * @param equalFn Function that compares if two elements are the same.
+ */
+export function unique<T>(
+  equalFn: (a: T, b: T) => boolean = (a, b) => a === b
+) {
+  return (value: T, index: number, array: T[]) =>
+    array.findIndex((v2) => equalFn(value, v2)) === index;
+}

--- a/packages/t2l-backend/src/externalApis/canvasApi.ts
+++ b/packages/t2l-backend/src/externalApis/canvasApi.ts
@@ -119,6 +119,7 @@ export default class CanvasClient {
     return this.client
       .listItems<Enrollment>(`courses/${courseId}/enrollments`, {
         include: ["user"],
+        type: ["StudentEnrollment"],
       })
       .toArray();
   }


### PR DESCRIPTION
This PR fixes two problems in the endpoint that returns the grades in "total column":

1. The Canvas API returns now only student enrollments
2. The response is filtered to delete duplicates