### PR TITLE
Check missing students

### DIFF
--- a/packages/t2l-backend/src/apiHandlers/ladokParticipants.ts
+++ b/packages/t2l-backend/src/apiHandlers/ladokParticipants.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from "express";
+import CanvasClient from "../externalApis/canvasApi";
+import {
+  getAktivitetstillfalleParticipants,
+  getKurstillfalleParticipants,
+} from "../externalApis/ladokApi";
+import { splitSections } from "./utils/commons";
+
+/**
+ * HTTP request: `/courses/:courseId/ladok-participants`
+ *
+ * Get a list of students that are enrolled in any kurstillfalle in Ladok
+ * that maps to a section within the course-room :courseId
+ */
+export async function getParticipantsHandler(
+  req: Request<{ courseId: string }>,
+  res: Response<string[]>
+) {
+  const courseId = req.params.courseId;
+  const canvasClient = new CanvasClient(req);
+  const sections = await canvasClient.getSections(courseId);
+  const { aktivitetstillfalleIds, kurstillfalleIds } = splitSections(sections);
+
+  const participants = new Set<string>();
+
+  if (kurstillfalleIds.length > 0) {
+    const { Identitet } = await getKurstillfalleParticipants(kurstillfalleIds);
+    for (const i of Identitet) {
+      participants.add(i);
+    }
+  }
+
+  if (aktivitetstillfalleIds.length > 0) {
+    for (const id of aktivitetstillfalleIds) {
+      const { Identitet } = await getAktivitetstillfalleParticipants(id);
+      for (const i of Identitet) {
+        participants.add(i);
+      }
+    }
+  }
+
+  return res.send(Array.from(participants));
+}

--- a/packages/t2l-backend/src/externalApis/ladokApi/index.ts
+++ b/packages/t2l-backend/src/externalApis/ladokApi/index.ts
@@ -12,7 +12,7 @@ import type {
   Behorighetsprofil,
   Betygsgrad,
   Kurstillfalle,
-  KurstillfalleParticipants,
+  ParticipantIds,
   RapporteringsMojlighetInput,
   RapporteringsMojlighetOutput,
   Resultat,
@@ -24,7 +24,10 @@ export * from "./types";
 const gotClient = got.extend({
   prefixUrl: process.env.LADOK_API_BASEURL,
   headers: {
-    Accept: "application/vnd.ladok-resultat+json",
+    Accept: [
+      "application/vnd.ladok-resultat+json",
+      "application/vnd.ladok-studiedeltagande+json",
+    ].join(","),
   },
   responseType: "json",
   https: {
@@ -83,13 +86,13 @@ export function getSkaFinnasStudenter(aktivitetstillfalleUID: string) {
 }
 
 /**
- *
+ * Get participants in a single aktivitetstillfalle
  */
 export async function getAktivitetstillfalleParticipants(
   aktivitetstillfalleUID: string
 ) {
   return gotClient
-    .get<KurstillfalleParticipants>(
+    .get<ParticipantIds>(
       `aktivitetstillfallesmojlighet/filtrera/studentidentiteter?aktivitetstillfalleUID=${aktivitetstillfalleUID}`
     )
     .then((response) => response.body);
@@ -119,12 +122,18 @@ export async function getKurstillfalleStructure(kurstillfalleUID: string) {
 
 export async function getKurstillfalleParticipants(kurstillfalleUID: string[]) {
   return gotClient
-    .put<KurstillfalleParticipants>(
+    .put<ParticipantIds>(
       `studiedeltagande/deltagare/kurstillfalle/studentidentiter`,
       {
         json: {
           utbildningstillfalleUID: kurstillfalleUID,
-          deltagaretillstand: ["EJ_PABORJAD", "REGISTRERAD"],
+          deltagaretillstand: [
+            "EJ_PABORJAD",
+            "REGISTRERAD",
+            "AVKLARAD",
+            "AVBROTT",
+            "ATERBUD",
+          ],
         },
       }
     )

--- a/packages/t2l-backend/src/externalApis/ladokApi/index.ts
+++ b/packages/t2l-backend/src/externalApis/ladokApi/index.ts
@@ -12,6 +12,7 @@ import type {
   Behorighetsprofil,
   Betygsgrad,
   Kurstillfalle,
+  KurstillfalleParticipants,
   RapporteringsMojlighetInput,
   RapporteringsMojlighetOutput,
   Resultat,
@@ -82,6 +83,19 @@ export function getSkaFinnasStudenter(aktivitetstillfalleUID: string) {
 }
 
 /**
+ *
+ */
+export async function getAktivitetstillfalleParticipants(
+  aktivitetstillfalleUID: string
+) {
+  return gotClient
+    .get<KurstillfalleParticipants>(
+      `aktivitetstillfallesmojlighet/filtrera/studentidentiteter?aktivitetstillfalleUID=${aktivitetstillfalleUID}`
+    )
+    .then((response) => response.body);
+}
+
+/**
  * Get the structure of a course round (kurstillfälle)
  * @see {@link https://www.integrationstest.ladok.se/restdoc/resultat.html#h%C3%A4mtaIng%C3%A5endeMomentF%C3%B6rKurstillf%C3%A4lle}
  */
@@ -101,6 +115,20 @@ export async function getKurstillfalleStructure(kurstillfalleUID: string) {
         throw e;
       }
     });
+}
+
+export async function getKurstillfalleParticipants(kurstillfalleUID: string[]) {
+  return gotClient
+    .put<KurstillfalleParticipants>(
+      `studiedeltagande/deltagare/kurstillfalle/studentidentiter`,
+      {
+        json: {
+          utbildningstillfalleUID: kurstillfalleUID,
+          deltagaretillstand: ["EJ_PABORJAD", "REGISTRERAD"],
+        },
+      }
+    )
+    .then((r) => r.body);
 }
 
 /**

--- a/packages/t2l-backend/src/externalApis/ladokApi/types.ts
+++ b/packages/t2l-backend/src/externalApis/ladokApi/types.ts
@@ -60,7 +60,7 @@ export interface Kurstillfalle {
 }
 
 /** Represents a list of participants in a Kurstillfalle */
-export interface KurstillfalleParticipants {
+export interface ParticipantIds {
   Identitet: string[];
 }
 

--- a/packages/t2l-backend/src/externalApis/ladokApi/types.ts
+++ b/packages/t2l-backend/src/externalApis/ladokApi/types.ts
@@ -59,6 +59,11 @@ export interface Kurstillfalle {
   }>;
 }
 
+/** Represents a list of participants in a Kurstillfalle */
+export interface KurstillfalleParticipants {
+  Identitet: string[];
+}
+
 export interface SkaFinnasStudenter {
   Utbildningstillfalle?: {
     /** Here is the Kurstillfalle UID */

--- a/packages/t2l-backend/src/router.ts
+++ b/packages/t2l-backend/src/router.ts
@@ -9,6 +9,7 @@ import { getGradesHandler, postGradesHandler } from "./apiHandlers/ladokGrades";
 import auth from "./otherHandlers/auth";
 import { monitor, about } from "./otherHandlers/system";
 import log from "skog";
+import { getParticipantsHandler } from "./apiHandlers/ladokParticipants";
 const router = Router();
 
 router.get("/_monitor", monitor);
@@ -46,6 +47,9 @@ router.get(
   (req, res, next) => assignmentGradesHandler(req, res).catch(next)
 );
 
+router.get("/api/courses/:courseId/ladok-participants", (req, res, next) =>
+  getParticipantsHandler(req, res).catch(next)
+);
 router.get("/api/courses/:courseId/ladok-grades", (req, res, next) =>
   getGradesHandler(req, res).catch(next)
 );

--- a/packages/t2l-frontend/src/hooks/apiClient.ts
+++ b/packages/t2l-frontend/src/hooks/apiClient.ts
@@ -71,6 +71,13 @@ export function useAssignments() {
   );
 }
 
+export function useLadokParticipants() {
+  const courseId = getCourseId();
+  return useQuery<string[]>(["participants", courseId], () =>
+    apiFetch(`/transfer-to-ladok/api/courses/${courseId}/ladok-participants`)
+  );
+}
+
 export function useGradeableStudents(destination: GradesDestination) {
   const courseId = getCourseId();
 

--- a/packages/t2l-frontend/src/utils/mergeGradesList.ts
+++ b/packages/t2l-frontend/src/utils/mergeGradesList.ts
@@ -50,12 +50,33 @@ export interface GradeWithStatus {
 export function getTransferencePreview(
   canvasGrades: CanvasGrades,
   ladokGradeableStudents: GradeableStudents,
+  ladokParticipantsId: string[],
   examinationDate: string
 ): GradeWithStatus[] {
   return canvasGrades.map<GradeWithStatus>((canvasGrade): GradeWithStatus => {
     const ladokGrade = ladokGradeableStudents.find(
       (ladokGrade) => ladokGrade.student.id === canvasGrade.student.id
     );
+
+    const isParticipant = ladokParticipantsId.find(
+      (p) => p === canvasGrade.student.id
+    );
+
+    if (!isParticipant) {
+      return {
+        status: "not_transferable",
+        canvasGrade: canvasGrade.grade,
+        student: {
+          id: canvasGrade.student.id,
+          sortableName: canvasGrade.student.sortableName,
+        },
+        cause: {
+          code: "not_participant",
+          message:
+            "The student does not exist in Ladok (any section in current room)",
+        },
+      };
+    }
 
     if (!ladokGrade) {
       return {
@@ -66,8 +87,8 @@ export function getTransferencePreview(
           sortableName: canvasGrade.student.sortableName,
         },
         cause: {
-          code: "not_in_ladok",
-          message: "The student is not in Ladok",
+          code: "not_participant_in_selected_section",
+          message: "The student does not exist in Ladok (user selection)",
         },
       };
     }


### PR DESCRIPTION
This PR shows to the user which grades are impossible to handle by Transfer to Ladok:

1. Implements a new API endpoint that returns IDs of all students enrolled in a course or examination room according to Ladok. The list include students that are registered, have completed the course or have abandoned it.
2. Shows a list of students that are present in Canvas but do not participate in Ladok.